### PR TITLE
Fix array attributes problem

### DIFF
--- a/lib/monkey_patch_activerecord.rb
+++ b/lib/monkey_patch_activerecord.rb
@@ -116,7 +116,7 @@ module ActiveRecord
       im = arel.create_insert
 
       # ****** BEGIN PARTITIONED PATCH ******
-      actual_arel_table = @klass.dynamic_arel_table(Hash[*values.map{|k,v| [k.name,v]}.flatten]) if @klass.respond_to?(:dynamic_arel_table)
+      actual_arel_table = @klass.dynamic_arel_table(Hash[*values.map{|k,v| [k.name,v]}.flatten(1)]) if @klass.respond_to?(:dynamic_arel_table)
       actual_arel_table = @table unless actual_arel_table
       # Original line:
       # im.into @table


### PR DESCRIPTION
Method `insert` receives params such as `[["blockers_ids", []], ["some_key", "some_value"]`, so array should be flatten only on 1 level to avoid removing empty arrays.
```ruby
[1] pry(main)> [["blockers_ids", []], ["some_key", "some_value"]].flatten
=> ["blockers_ids", "some_key", "some_value"]
[2] pry(main)> [["blockers_ids", []], ["some_key", "some_value"]].flatten(1)
=> ["blockers_ids", [], "some_key", "some_value"]
```