### PR TITLE
Update to fix prefetch_primary_key 

### DIFF
--- a/lib/monkey_patch_postgres.rb
+++ b/lib/monkey_patch_postgres.rb
@@ -66,7 +66,7 @@ module ActiveRecord::ConnectionAdapters
     #
     # @param [String] table_name the table name to query
     # @return [Boolean] returns true if the table should have its primary key prefetched.
-    def prefetch_primary_key?(table_name)
+    def prefetch_primary_key?(table_name = nil)
       return false
     end
 


### PR DESCRIPTION
prefetch_primary_key should  have default to allow calling with no parameters.

You already have  a fix for this on the 5.0 branch.