### PR TITLE
Removed the monkey patch of add_foreign_key 

### DIFF
--- a/lib/monkey_patch_postgres.rb
+++ b/lib/monkey_patch_postgres.rb
@@ -107,8 +107,8 @@ module ActiveRecord::ConnectionAdapters
     # @param [String] referenced_table_name the name of the table referenced by the foreign key
     # @param [String] referenced_field_name (:id) the name of the column referenced by the foreign key
     # @return [optional] undefined
-    def add_foreign_key(referencing_table_name, referencing_field_name, referenced_table_name, referenced_field_name = :id)
-      execute("ALTER TABLE #{referencing_table_name} add foreign key (#{referencing_field_name}) references #{referenced_table_name}(#{referenced_field_name})")
-    end
+    # def add_foreign_key(referencing_table_name, referencing_field_name, referenced_table_name, referenced_field_name = :id)
+    #   execute("ALTER TABLE #{referencing_table_name} add foreign key (#{referencing_field_name}) references #{referenced_table_name}(#{referenced_field_name})")
+    # end
   end
 end


### PR DESCRIPTION
The function prototype in the money patch is:
`def add_foreign_key(referencing_table_name, referencing_field_name, referenced_table_name, referenced_field_name = :id)`

The function protoype in ActiveRecord is:
`def add_foreign_key(to_table, options)`

This means that many of the documented ways to call add_foreign_key in a migration do not work.

Please feel free to tell what I am missing here and suggest a better solution, but with this change in place, everything is working again.

